### PR TITLE
feat: improved scanning speed by skipping lines with few chars

### DIFF
--- a/detect_secrets/constants.py
+++ b/detect_secrets/constants.py
@@ -1,6 +1,10 @@
-from enum import Enum
+from __future__ import annotations
 
-from .core.potential_secret import PotentialSecret
+from enum import Enum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .core.potential_secret import PotentialSecret
 
 
 class VerifiedResult(Enum):

--- a/detect_secrets/core/scan.py
+++ b/detect_secrets/core/scan.py
@@ -25,7 +25,7 @@ from .log import log
 from .plugins import Plugin
 from .potential_secret import PotentialSecret
 
-MIN_LINE_LENGTH = int(os.getenv("CHECKOV_MIN_LINE_LENGTH", "5"))
+MIN_LINE_LENGTH = int(os.getenv('CHECKOV_MIN_LINE_LENGTH', '5'))
 
 
 def get_files_to_scan(

--- a/detect_secrets/core/scan.py
+++ b/detect_secrets/core/scan.py
@@ -25,6 +25,8 @@ from .log import log
 from .plugins import Plugin
 from .potential_secret import PotentialSecret
 
+MIN_LINE_LENGTH = int(os.getenv("CHECKOV_MIN_LINE_LENGTH", "5"))
+
 
 def get_files_to_scan(
     *paths: str,
@@ -311,8 +313,11 @@ def _process_line_based_plugins(
     # NOTE: We iterate through lines *then* plugins, because we want to quit early if any of the
     # filters return True.
     for line_number, line in lines:
-        log.debug(f'Processing {filename}:{line_number}')
-        line = line.rstrip()
+        line = line.strip()
+        if len(line) < MIN_LINE_LENGTH:
+            # skip lines which have too few none whitespace chars
+            continue
+
         code_snippet = get_code_snippet(
             lines=line_content,
             line_number=line_number,

--- a/tests/core/scan_test.py
+++ b/tests/core/scan_test.py
@@ -1,6 +1,7 @@
 import os
 import textwrap
 from pathlib import Path
+from unittest import mock
 
 import pytest
 
@@ -95,6 +96,18 @@ class TestScanFile:
             f.seek(0)
 
             assert not list(scan.scan_file(f.name))
+
+    @staticmethod
+    def test_skip_whitespace_lines():
+        with mock_named_temporary_file(suffix='.txt') as f:
+            f.write(
+                "\n".join(["          "] * 10000).encode(),
+            )
+            f.seek(0)
+
+            with mock.patch('detect_secrets.core.scan.get_code_snippet') as m:
+                assert not list(scan.scan_file(f.name))
+                assert not m.called
 
 
 @pytest.fixture(autouse=True)

--- a/tests/core/scan_test.py
+++ b/tests/core/scan_test.py
@@ -101,7 +101,7 @@ class TestScanFile:
     def test_skip_whitespace_lines():
         with mock_named_temporary_file(suffix='.txt') as f:
             f.write(
-                "\n".join(["          "] * 10000).encode(),
+                '\n'.join(['          '] * 10000).encode(),
             )
             f.seek(0)
 


### PR DESCRIPTION
- added an env var `CHECKOV_MIN_LINE_LENGTH` to skip lines with only a few chars (default less than 5), which improves the scanning speed especially for line heavy files with only few chars per line, like formatted JSON files