### PR TITLE
fix - get raw_context for multiline scan and diff scan

### DIFF
--- a/detect_secrets/core/scan.py
+++ b/detect_secrets/core/scan.py
@@ -35,7 +35,7 @@ def read_raw_lines(file_name: str) -> List[str]:
         with open(file_name) as f:
             return f.readlines()
     except IOError:
-        log.warning(f"Can't open file {file_name}")
+        log.debug(f"Can't open file {file_name}")
         return []
 
 

--- a/detect_secrets/core/scan.py
+++ b/detect_secrets/core/scan.py
@@ -341,6 +341,11 @@ def _process_line_based_plugins(
             lines=line_content,
             line_number=line_number,
         )
+        raw_lines = read_raw_lines(filename) if not is_added and not is_removed else []
+        raw_code_snippet = get_code_snippet(
+            lines=raw_lines,
+            line_number=line_number,
+        )
 
         # We apply line-specific filters, and see whether that allows us to quit early.
         if _is_filtered_out(
@@ -360,6 +365,7 @@ def _process_line_based_plugins(
                 line=line,
                 line_number=line_number,
                 context=code_snippet,
+                raw_context=raw_code_snippet,
                 is_added=is_added,
                 is_removed=is_removed,
             )

--- a/detect_secrets/core/scan.py
+++ b/detect_secrets/core/scan.py
@@ -30,9 +30,13 @@ MIN_LINE_LENGTH = int(os.getenv('CHECKOV_MIN_LINE_LENGTH', '5'))
 
 
 @lru_cache(maxsize=1)
-def read_raw_lines(filename: str) -> List[str]:
-    with open(filename) as f:
-        return f.readlines()
+def read_raw_lines(file_name: str) -> List[str]:
+    try:
+        with open(file_name) as f:
+            return f.readlines()
+    except IOError:
+        log.warning(f"Can't open file {file_name}")
+        return []
 
 
 def get_files_to_scan(
@@ -341,9 +345,8 @@ def _process_line_based_plugins(
             lines=line_content,
             line_number=line_number,
         )
-        raw_lines = read_raw_lines(filename) if not is_added and not is_removed else []
         raw_code_snippet = get_code_snippet(
-            lines=raw_lines,
+            lines=read_raw_lines(filename),
             line_number=line_number,
         )
 


### PR DESCRIPTION
fix - add raw_context

until now we get the raw_context for the multiline scan with the function `open(filename) as f`.  
in the scan diff in the simple run, we get a string with the `git diff` and we can't open the file_name the git diff refers to so the function to get the raw_context fails.
so I added a try except in the read_raw_lines function. to return an empty list if the open file fails 
