### PR TITLE
Compare uuid match to secret

### DIFF
--- a/detect_secrets/filters/heuristic.py
+++ b/detect_secrets/filters/heuristic.py
@@ -51,7 +51,10 @@ def is_sequential_string(secret: str) -> bool:
 
 def is_potential_uuid(secret: str) -> bool:
     match = _get_uuid_regex().search(secret)
-    return bool(match) and match.group() == secret
+    if not match:
+        return False
+
+    return match.group() == secret
 
 
 @lru_cache(maxsize=1)

--- a/detect_secrets/filters/heuristic.py
+++ b/detect_secrets/filters/heuristic.py
@@ -50,7 +50,7 @@ def is_sequential_string(secret: str) -> bool:
 
 
 def is_potential_uuid(secret: str) -> bool:
-    return bool(_get_uuid_regex().search(secret))
+    return _get_uuid_regex().search(secret).group() == secret
 
 
 @lru_cache(maxsize=1)

--- a/detect_secrets/filters/heuristic.py
+++ b/detect_secrets/filters/heuristic.py
@@ -50,7 +50,8 @@ def is_sequential_string(secret: str) -> bool:
 
 
 def is_potential_uuid(secret: str) -> bool:
-    return _get_uuid_regex().search(secret).group() == secret
+    match = _get_uuid_regex().search(secret)
+    return match and match.group() == secret
 
 
 @lru_cache(maxsize=1)

--- a/detect_secrets/filters/heuristic.py
+++ b/detect_secrets/filters/heuristic.py
@@ -51,7 +51,7 @@ def is_sequential_string(secret: str) -> bool:
 
 def is_potential_uuid(secret: str) -> bool:
     match = _get_uuid_regex().search(secret)
-    return match and match.group() == secret
+    return bool(match) and match.group() == secret
 
 
 @lru_cache(maxsize=1)

--- a/tests/filters/heuristic_filter_test.py
+++ b/tests/filters/heuristic_filter_test.py
@@ -47,7 +47,7 @@ class TestIsSequentialString:
     [
         ('3636dd46-ea21-11e9-81b4-2a2ae2dbcce4', True),  # uuid1
         ('97fb0431-46ac-41df-9ef9-1a18545ce2a0', True),  # uuid4
-        ('prefix-3636dd46-ea21-11e9-81b4-2a2ae2dbcce4-suffix', False)  # uuid in middle of string
+        ('prefix-3636dd46-ea21-11e9-81b4-2a2ae2dbcce4-suffix', False),  # uuid in middle of string
     ]
 )
 def test_is_potential_uuid(secret, expected_value):

--- a/tests/filters/heuristic_filter_test.py
+++ b/tests/filters/heuristic_filter_test.py
@@ -43,15 +43,15 @@ class TestIsSequentialString:
 
 
 @pytest.mark.parametrize(
-    'secret',
-    (
-        '3636dd46-ea21-11e9-81b4-2a2ae2dbcce4',  # uuid1
-        '97fb0431-46ac-41df-9ef9-1a18545ce2a0',  # uuid4
-        'prefix-3636dd46-ea21-11e9-81b4-2a2ae2dbcce4-suffix',  # uuid in middle of string
-    ),
+    'secret, expected_value',
+    [
+        ('3636dd46-ea21-11e9-81b4-2a2ae2dbcce4', True),  # uuid1
+        ('97fb0431-46ac-41df-9ef9-1a18545ce2a0', True),  # uuid4
+        ('prefix-3636dd46-ea21-11e9-81b4-2a2ae2dbcce4-suffix', False)  # uuid in middle of string
+    ]
 )
-def test_is_potential_uuid(secret):
-    assert filters.heuristic.is_potential_uuid(secret)
+def test_is_potential_uuid(secret, expected_value):
+    assert filters.heuristic.is_potential_uuid(secret) == expected_value
 
 
 class TestIsLikelyIdString:

--- a/tests/filters/heuristic_filter_test.py
+++ b/tests/filters/heuristic_filter_test.py
@@ -48,7 +48,7 @@ class TestIsSequentialString:
         ('3636dd46-ea21-11e9-81b4-2a2ae2dbcce4', True),  # uuid1
         ('97fb0431-46ac-41df-9ef9-1a18545ce2a0', True),  # uuid4
         ('prefix-3636dd46-ea21-11e9-81b4-2a2ae2dbcce4-suffix', False),  # uuid in middle of string
-    ]
+    ],
 )
 def test_is_potential_uuid(secret, expected_value):
     assert filters.heuristic.is_potential_uuid(secret) == expected_value


### PR DESCRIPTION
The previous functionality stated that if the secret **contained** a uuid pattern then we should skip it.

But, some secrets include a uuid pattern with a prefix - and it would wrongly filter them as well.

The new functionality checks that the uuid pattern matches the entire secret and not part of it.