### PR TITLE
validate length of base64 entropy secret

### DIFF
--- a/detect_secrets/plugins/high_entropy_strings.py
+++ b/detect_secrets/plugins/high_entropy_strings.py
@@ -38,10 +38,17 @@ class HighEntropyStringsPlugin(BasePlugin, metaclass=ABCMeta):
                 # This occurs on the default regex, but not on the eager regex.
                 result = result[1]
 
+            if not self.validate_result(result=result):
+                continue
+
             # We perform the shannon entropy check in `analyze_line` instead, so that we have
             # more control over **when** we display the results of this plugin. Specifically,
             # this allows us to show the computed entropy values during adhoc string scans.
             yield result
+
+    def validate_result(self, result: str) -> bool:
+        """This can be overridden to check, if the string is valid result"""
+        return True
 
     def analyze_line(
             self,
@@ -161,6 +168,11 @@ class Base64HighEntropyString(HighEntropyStringsPlugin):
             ),
             limit=limit,
         )
+
+    def validate_result(self, result: str) -> bool:
+        # a base64 string is a multiple of 4 chars
+        result_division = len(result) / 4
+        return bool(result_division == int(result_division))
 
 
 class HexHighEntropyString(HighEntropyStringsPlugin):

--- a/tests/plugins/high_entropy_strings_test.py
+++ b/tests/plugins/high_entropy_strings_test.py
@@ -58,9 +58,9 @@ class TestHighEntropyString:
                 1,
             ),
             (
-                # We add an 'a' to make the second secret different.
+                # We add an 'abcd' to make the second secret different.
                 # This currently fits both hex and base64 char set.
-                'String #1: "{secret}"; String #2: "{secret}a"',
+                'String #1: "{secret}"; String #2: "{secret}abcd"',
                 2,
             ),
         ),
@@ -128,3 +128,27 @@ class TestHexEntropyCalculation:
             HexHighEntropyString().calculate_shannon_entropy(value)
             == original_hex_detector().calculate_shannon_entropy(value)
         )
+
+
+@pytest.mark.parametrize(
+    'line, num_results',
+    (
+        (
+            "secret: 'c3VwZXIgbG9uZyBzdHJpbmcgc2hvdWxkIGNhdXNlIGVub3VnaCBlbnRyb3B5'",
+            1,
+        ),
+        (
+            "secret: 'c3VwZXIgbG9uZyBzdHJpbmcgc2hvdWxkIGNhdXNlIGVub3VnaCBlbnRyb3B5='",
+            0,
+        ),
+    ),
+)
+def test_base64_entropy_ignore_invalid_length_strings(line, num_results):
+    results = list(
+        Base64HighEntropyString().analyze_line(
+            filename='does not matter',
+            line=line,
+            line_number=0,
+        ),
+    )
+    assert len(results) == num_results


### PR DESCRIPTION
improves the amount of false positives assumed to be base64 strings
