### PR TITLE
check Azure Storage Key for surrounding quotes

### DIFF
--- a/detect_secrets/core/plugins/util.py
+++ b/detect_secrets/core/plugins/util.py
@@ -1,5 +1,4 @@
 import inspect
-from abc import abstractproperty
 from functools import lru_cache
 from types import ModuleType
 from typing import Any
@@ -62,5 +61,5 @@ def _is_valid_plugin(attribute: Any) -> bool:
         inspect.isclass(attribute)
         and issubclass(attribute, BasePlugin)
         # Heuristic to determine abstract classes
-        and not isinstance(attribute.secret_type, abstractproperty)
+        and 'secret_type' not in attribute.__abstractmethods__
     )

--- a/detect_secrets/plugins/azure_storage_key.py
+++ b/detect_secrets/plugins/azure_storage_key.py
@@ -13,6 +13,6 @@ class AzureStorageKeyDetector(RegexBasedDetector):
     denylist = [
         # Account Key (AccountKey=xxxxxxxxx)
         re.compile(
-            r'(?:[A-Za-z0-9+\/]{86,1000}==)$',
+            r'(?:["\']?[A-Za-z0-9+\/]{86,1000}==["\']?)$',
         ),
     ]

--- a/detect_secrets/plugins/base.py
+++ b/detect_secrets/plugins/base.py
@@ -8,9 +8,8 @@ things may not work as you expect (see the scan logic in SecretsCollection).
 from __future__ import annotations
 
 import re
-from abc import ABCMeta
+from abc import ABC
 from abc import abstractmethod
-from abc import abstractproperty
 from typing import Any
 from typing import Dict
 from typing import Generator
@@ -27,8 +26,9 @@ from detect_secrets.util.code_snippet import CodeSnippet
 from detect_secrets.util.inject import call_function_with_arguments
 
 
-class BasePlugin(metaclass=ABCMeta):
-    @abstractproperty
+class BasePlugin(ABC):
+    @property
+    @abstractmethod
     def secret_type(self) -> str:
         """
         Unique, user-facing description to identify this type of secret. This should be overloaded
@@ -149,7 +149,7 @@ class BasePlugin(metaclass=ABCMeta):
         return self.json() == other.json()
 
 
-class RegexBasedDetector(BasePlugin, metaclass=ABCMeta):
+class RegexBasedDetector(BasePlugin):
     """Parent class for regular-expression based detectors.
 
     To create a new regex-based detector, subclass this and set `secret_type` with a
@@ -164,7 +164,8 @@ class RegexBasedDetector(BasePlugin, metaclass=ABCMeta):
         )
     """
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def denylist(self) -> Iterable[Pattern]:
         raise NotImplementedError
 

--- a/tests/plugins/azure_storage_key_test.py
+++ b/tests/plugins/azure_storage_key_test.py
@@ -13,6 +13,14 @@ class TestAzureStorageKeyDetector:
                 True,
             ),
             (
+                'AccountKey="lJzRc1YdHaAA2KCNJJ1tkYwF/+mKK6Ygw0NGe170Xu592euJv2wYUtBlV8z+qnlcNQSnIYVTkLWntUO1F8j8rQ=="',  # noqa: E501
+                True,
+            ),
+            (
+                "AccountKey='lJzRc1YdHaAA2KCNJJ1tkYwF/+mKK6Ygw0NGe170Xu592euJv2wYUtBlV8z+qnlcNQSnIYVTkLWntUO1F8j8rQ=='",  # noqa: E501
+                True,
+            ),
+            (
                 'lJzRc1YdHaAA2KCNJJ1tkYwF/+mKK6Ygw0NGe170Xu592euJv2wYUtBlV8z+qnlcNQSnIYVTkLWntUO1F8j8rQ==',  # noqa: E501
                 True,
             ),


### PR DESCRIPTION
- Azure storage Keys can be sometimes surrounded by quotes
- replaced the deprecated `@abstractproperty` annotation

Fixes bridgecrewio/checkov#5598
