### PR TITLE
AzureStorageKeyDetector scan multi lines and skip public keys

### DIFF
--- a/detect_secrets/plugins/azure_storage_key.py
+++ b/detect_secrets/plugins/azure_storage_key.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 
 import re
 
+from typing import Any
+from typing import Optional
+from typing import Set
+
 from detect_secrets.core.potential_secret import PotentialSecret
 from detect_secrets.plugins.base import RegexBasedDetector
 from detect_secrets.util.code_snippet import CodeSnippet
-
-from typing import Any
-from typing import Set
-from typing import Optional
 
 class AzureStorageKeyDetector(RegexBasedDetector):
     """Scans for Azure Storage Account access keys."""

--- a/detect_secrets/plugins/azure_storage_key.py
+++ b/detect_secrets/plugins/azure_storage_key.py
@@ -56,12 +56,13 @@ class AzureStorageKeyDetector(RegexBasedDetector):
         return set(result for result in set(results) if not self.skip_keys_exists(result, context_text))
 
     def skip_keys_exists(self, result: PotentialSecret, string: str) -> bool:
-        for secret_regex in self.skip_keys:
-            regex = re.compile(
-                secret_regex.format(
-                    secret=re.escape(result.secret_value),
-                ), re.DOTALL,
-            )
-            if regex.search(string) is not None:
-                return True
+        if result.secret_value:
+            for secret_regex in self.skip_keys:
+                regex = re.compile(
+                    secret_regex.format(
+                        secret=re.escape(result.secret_value),
+                    ), re.DOTALL,
+                )
+                if regex.search(string) is not None:
+                    return True
         return False

--- a/detect_secrets/plugins/azure_storage_key.py
+++ b/detect_secrets/plugins/azure_storage_key.py
@@ -52,8 +52,8 @@ class AzureStorageKeyDetector(RegexBasedDetector):
             context: Optional[CodeSnippet],
             line: str,
     ) -> Set[PotentialSecret]:
-        context_text = ''.join(context.lines) if context else line;
-        return set(result for result in set(results) if not self.skip_keys_exists(result, context_text))
+        context_text = ''.join(context.lines) if context else line
+        return [result for result in results if not self.skip_keys_exists(result, context_text)]
 
     def skip_keys_exists(self, result: PotentialSecret, string: str) -> bool:
         if result.secret_value:

--- a/detect_secrets/plugins/azure_storage_key.py
+++ b/detect_secrets/plugins/azure_storage_key.py
@@ -5,10 +5,13 @@ from __future__ import annotations
 
 import re
 
+from detect_secrets.core.potential_secret import PotentialSecret
 from detect_secrets.plugins.base import RegexBasedDetector
 from detect_secrets.util.code_snippet import CodeSnippet
-from detect_secrets.core.potential_secret import PotentialSecret
 
+from typing import Any
+from typing import Set
+from typing import Optional
 
 class AzureStorageKeyDetector(RegexBasedDetector):
     """Scans for Azure Storage Account access keys."""
@@ -50,13 +53,15 @@ class AzureStorageKeyDetector(RegexBasedDetector):
             line: str,
     ) -> Set[PotentialSecret]:
         context_text = ''.join(context.lines) if context else line;
-        return [result for result in set(results) if not self.skip_keys_exists(result, context_text)]
+        return set(result for result in set(results) if not self.skip_keys_exists(result, context_text))
 
     def skip_keys_exists(self, result: PotentialSecret, string: str) -> bool:
         for secret_regex in self.skip_keys:
-            regex = re.compile(secret_regex.format(
-                secret= re.escape(result.secret_value),
-            ), re.DOTALL)
+            regex = re.compile(
+                secret_regex.format(
+                    secret=re.escape(result.secret_value),
+                ), re.DOTALL,
+            )
             if regex.search(string) is not None:
                 return True
         return False

--- a/detect_secrets/plugins/azure_storage_key.py
+++ b/detect_secrets/plugins/azure_storage_key.py
@@ -1,9 +1,13 @@
 """
 This plugin searches for Azure Storage Account access keys.
 """
+from __future__ import annotations
+
 import re
 
 from detect_secrets.plugins.base import RegexBasedDetector
+from detect_secrets.util.code_snippet import CodeSnippet
+from detect_secrets.core.potential_secret import PotentialSecret
 
 
 class AzureStorageKeyDetector(RegexBasedDetector):
@@ -16,3 +20,43 @@ class AzureStorageKeyDetector(RegexBasedDetector):
             r'(?:["\']?[A-Za-z0-9+\/]{86,1000}==["\']?)$',
         ),
     ]
+
+    skip_keys = [
+        r'PublicKey[s]?:[a-z-\s\n>]*{secret}',
+    ]
+
+    def analyze_line(
+            self,
+            filename: str,
+            line: str,
+            line_number: int = 0,
+            context: Optional[CodeSnippet] = None,
+            raw_context: Optional[CodeSnippet] = None,
+            **kwargs: Any,
+    ) -> Set[PotentialSecret]:
+        output: Set[PotentialSecret] = set()
+        results = super().analyze_line(
+            filename=filename, line=line, line_number=line_number,
+            context=context, raw_context=raw_context, **kwargs,
+        )
+        output.update(self.filter_skip_keys(results, context, line))
+
+        return output
+
+    def filter_skip_keys(
+            self,
+            results: Set[PotentialSecret],
+            context: Optional[CodeSnippet],
+            line: str,
+    ) -> Set[PotentialSecret]:
+        context_text = ''.join(context.lines) if context else line;
+        return [result for result in set(results) if not self.skip_keys_exists(result, context_text)]
+
+    def skip_keys_exists(self, result: PotentialSecret, string: str) -> bool:
+        for secret_regex in self.skip_keys:
+            regex = re.compile(secret_regex.format(
+                secret= re.escape(result.secret_value),
+            ), re.DOTALL)
+            if regex.search(string) is not None:
+                return True
+        return False

--- a/detect_secrets/plugins/azure_storage_key.py
+++ b/detect_secrets/plugins/azure_storage_key.py
@@ -4,7 +4,6 @@ This plugin searches for Azure Storage Account access keys.
 from __future__ import annotations
 
 import re
-
 from typing import Any
 from typing import Optional
 from typing import Set

--- a/detect_secrets/plugins/azure_storage_key.py
+++ b/detect_secrets/plugins/azure_storage_key.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import re
 from typing import Any
+from typing import List
 from typing import Optional
 from typing import Set
 
@@ -50,7 +51,7 @@ class AzureStorageKeyDetector(RegexBasedDetector):
             results: Set[PotentialSecret],
             context: Optional[CodeSnippet],
             line: str,
-    ) -> Set[PotentialSecret]:
+    ) -> List[PotentialSecret]:
         context_text = ''.join(context.lines) if context else line
         return [result for result in results if not self.skip_keys_exists(result, context_text)]
 

--- a/tests/plugins/azure_storage_key_test.py
+++ b/tests/plugins/azure_storage_key_test.py
@@ -39,43 +39,43 @@ class TestAzureStorageKeyDetector:
 
             # Test skip only public keys
             (
-                "PublicKey: lJzRc1YdHaAA2KCNJJ1tkYwF/+mKK6Ygw0NGe170Xu592euJv2wYUtBlV8z+qnlcNQSnIYVTkLWntUO1F8j8rQ==",
+                'PublicKey: lJzRc1YdHaAA2KCNJJ1tkYwF/+mKK6Ygw0NGe170Xu592euJv2wYUtBlV8z+qnlcNQSnIYVTkLWntUO1F8j8rQ==',
                 False,
             ),
             (
-                "PublicKey: ssh-rsa lJzRc1YdHaAA2KCNJJ1tkYwF/+mKK6Ygw0NGe170Xu592euJv2wYUtBlV8z+qnlcNQSnIYVTkLWntUO1F8j8rQ==",
+                'PublicKey: ssh-rsa lJzRc1YdHaAA2KCNJJ1tkYwF/+mKK6Ygw0NGe170Xu592euJv2wYUtBlV8z+qnlcNQSnIYVTkLWntUO1F8j8rQ==',
                 False,
             ),
             (
-                "SshPublicKey: ssh-rsa lJzRc1YdHaAA2KCNJJ1tkYwF/+mKK6Ygw0NGe170Xu592euJv2wYUtBlV8z+qnlcNQSnIYVTkLWntUO1F8j8rQ==",
+                'SshPublicKey: ssh-rsa lJzRc1YdHaAA2KCNJJ1tkYwF/+mKK6Ygw0NGe170Xu592euJv2wYUtBlV8z+qnlcNQSnIYVTkLWntUO1F8j8rQ==',
                     False,
             ),
             (
-                "PublicKeys: lJzRc1YdHaAA2KCNJJ1tkYwF/+mKK6Ygw0NGe170Xu592euJv2wYUtBlV8z+qnlcNQSnIYVTkLWntUO1F8j8rQ==",
+                'PublicKeys: lJzRc1YdHaAA2KCNJJ1tkYwF/+mKK6Ygw0NGe170Xu592euJv2wYUtBlV8z+qnlcNQSnIYVTkLWntUO1F8j8rQ==',
                 False,
             ),
             (
-                "SshPublicKeys: lJzRc1YdHaAA2KCNJJ1tkYwF/+mKK6Ygw0NGe170Xu592euJv2wYUtBlV8z+qnlcNQSnIYVTkLWntUO1F8j8rQ==",
+                'SshPublicKeys: lJzRc1YdHaAA2KCNJJ1tkYwF/+mKK6Ygw0NGe170Xu592euJv2wYUtBlV8z+qnlcNQSnIYVTkLWntUO1F8j8rQ==',
                 False,
             ),
             (
-                "PrivateKeys: lJzRc1YdHaAA2KCNJJ1tkYwF/+mKK6Ygw0NGe170Xu592euJv2wYUtBlV8z+qnlcNQSnIYVTkLWntUO1F8j8rQ==",
+                'PrivateKeys: lJzRc1YdHaAA2KCNJJ1tkYwF/+mKK6Ygw0NGe170Xu592euJv2wYUtBlV8z+qnlcNQSnIYVTkLWntUO1F8j8rQ==',
                 True,
             ),
 
             # Test multilines
             (
-                """PrivateKeys: 
+                """PrivateKeys:
                 - lJzRc1YdHaAA2KCNJJ1tkYwF/+mKK6Ygw0NGe170Xu592euJv2wYUtBlV8z+qnlcNQSnIYVTkLWntUO1F8j8rQ==""",
                 True,
             ),
             (
-                """SshPublicKeys: 
+                """SshPublicKeys:
                 - lJzRc1YdHaAA2KCNJJ1tkYwF/+mKK6Ygw0NGe170Xu592euJv2wYUtBlV8z+qnlcNQSnIYVTkLWntUO1F8j8rQ==""",
                 False,
             ),
             (
-                """SshPublicKeys: 
+                """SshPublicKeys:
                 - >-
                 lJzRc1YdHaAA2KCNJJ1tkYwF/+mKK6Ygw0NGe170Xu592euJv2wYUtBlV8z+qnlcNQSnIYVTkLWntUO1F8j8rQ==""",
                 False,

--- a/tests/plugins/azure_storage_key_test.py
+++ b/tests/plugins/azure_storage_key_test.py
@@ -36,6 +36,50 @@ class TestAzureStorageKeyDetector:
                 'cret',
                 False,
             ),
+
+            # Test skip only public keys
+            (
+                "PublicKey: lJzRc1YdHaAA2KCNJJ1tkYwF/+mKK6Ygw0NGe170Xu592euJv2wYUtBlV8z+qnlcNQSnIYVTkLWntUO1F8j8rQ==",
+                False,
+            ),
+            (
+                "PublicKey: ssh-rsa lJzRc1YdHaAA2KCNJJ1tkYwF/+mKK6Ygw0NGe170Xu592euJv2wYUtBlV8z+qnlcNQSnIYVTkLWntUO1F8j8rQ==",
+                False,
+            ),
+            (
+                "SshPublicKey: ssh-rsa lJzRc1YdHaAA2KCNJJ1tkYwF/+mKK6Ygw0NGe170Xu592euJv2wYUtBlV8z+qnlcNQSnIYVTkLWntUO1F8j8rQ==",
+                    False,
+            ),
+            (
+                "PublicKeys: lJzRc1YdHaAA2KCNJJ1tkYwF/+mKK6Ygw0NGe170Xu592euJv2wYUtBlV8z+qnlcNQSnIYVTkLWntUO1F8j8rQ==",
+                False,
+            ),
+            (
+                "SshPublicKeys: lJzRc1YdHaAA2KCNJJ1tkYwF/+mKK6Ygw0NGe170Xu592euJv2wYUtBlV8z+qnlcNQSnIYVTkLWntUO1F8j8rQ==",
+                False,
+            ),
+            (
+                "PrivateKeys: lJzRc1YdHaAA2KCNJJ1tkYwF/+mKK6Ygw0NGe170Xu592euJv2wYUtBlV8z+qnlcNQSnIYVTkLWntUO1F8j8rQ==",
+                True,
+            ),
+
+            # Test multilines
+            (
+                """PrivateKeys: 
+                - lJzRc1YdHaAA2KCNJJ1tkYwF/+mKK6Ygw0NGe170Xu592euJv2wYUtBlV8z+qnlcNQSnIYVTkLWntUO1F8j8rQ==""",
+                True,
+            ),
+            (
+                """SshPublicKeys: 
+                - lJzRc1YdHaAA2KCNJJ1tkYwF/+mKK6Ygw0NGe170Xu592euJv2wYUtBlV8z+qnlcNQSnIYVTkLWntUO1F8j8rQ==""",
+                False,
+            ),
+            (
+                """SshPublicKeys: 
+                - >-
+                lJzRc1YdHaAA2KCNJJ1tkYwF/+mKK6Ygw0NGe170Xu592euJv2wYUtBlV8z+qnlcNQSnIYVTkLWntUO1F8j8rQ==""",
+                False,
+            ),
         ],
     )
     def test_analyze(self, payload, should_flag):


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added
<!-- (for bug fixes / features) -->
- [x] Docs have been added / updated
<!-- (for bug fixes / features) -->
- [x] All CI checks are green

* **What kind of change does this PR introduce?**
Update azure_storage_key plugin to skip public keys and scan multiline if key and value are located in different lines

* **What is the current behavior?**

detected secret in public key (single line)
```
SshPublicKeys: ssh-rsa lJzRc1YdHaAA2KCNJJ1tkYwF/+mKK6Ygw0NGe170Xu592euJv2wYUtBlV8z+qnlcNQSnIYVTkLWntUO1F8j8rQ=="
```

detected secret in public key (multi line)
```
SshPublicKeys: 
- >-
ssh-rsa lJzRc1YdHaAA2KCNJJ1tkYwF/+mKK6Ygw0NGe170Xu592euJv2wYUtBlV8z+qnlcNQSnIYVTkLWntUO1F8j8rQ=="
```

* **What is the new behavior (if this is a feature change)?**

NOT detected secret in public key (single line) 
```
SshPublicKeys: ssh-rsa lJzRc1YdHaAA2KCNJJ1tkYwF/+mKK6Ygw0NGe170Xu592euJv2wYUtBlV8z+qnlcNQSnIYVTkLWntUO1F8j8rQ=="
```

NOT detected secret in public key (multi line)
```
SshPublicKeys: 
- >-
ssh-rsa lJzRc1YdHaAA2KCNJJ1tkYwF/+mKK6Ygw0NGe170Xu592euJv2wYUtBlV8z+qnlcNQSnIYVTkLWntUO1F8j8rQ=="
```

* **Does this PR introduce a breaking change?**
nothing

* **Other information**:
