### PR TITLE
AzureStorageKeyDetector should flag a secret in two scenarios

### DIFF
--- a/detect_secrets/plugins/azure_storage_key.py
+++ b/detect_secrets/plugins/azure_storage_key.py
@@ -20,14 +20,19 @@ class AzureStorageKeyDetector(RegexBasedDetector):
     denylist = [
         # Account Key (AccountKey=xxxxxxxxx)
         re.compile(
-            r'(?:["\']?[A-Za-z0-9+\/]{86,1000}==["\']?)$',
+            r'(?:["\']?[A-Za-z0-9+\/]{86,1000}==["\']?)',
         ),
     ]
 
-    skip_keys = [
-        r'PublicKey[s]?:[a-z-\s\n>]*{secret}',
-    ]
+    context_keys = [
+        r'AccountKey=\s*{secret}',
 
+        # maximum 2 lines secret distance under azure mention (case-insensitive)
+        r'(?i)azure.*\n?.*\n?.*{secret}',
+
+        # maximum 2 lines secret distance above azure mention (case-insensitive)
+        r'{secret}.*\n?.*\n?.*azure',
+    ]
     def analyze_line(
             self,
             filename: str,
@@ -42,26 +47,26 @@ class AzureStorageKeyDetector(RegexBasedDetector):
             filename=filename, line=line, line_number=line_number,
             context=context, raw_context=raw_context, **kwargs,
         )
-        output.update(self.filter_skip_keys(results, context, line))
+        output.update(self.analyze_context_keys(results, context, line))
 
         return output
 
-    def filter_skip_keys(
+    def analyze_context_keys(
             self,
             results: Set[PotentialSecret],
             context: Optional[CodeSnippet],
             line: str,
     ) -> List[PotentialSecret]:
         context_text = ''.join(context.lines) if context else line
-        return [result for result in results if not self.skip_keys_exists(result, context_text)]
+        return [result for result in results if self.context_keys_exists(result, context_text)]
 
-    def skip_keys_exists(self, result: PotentialSecret, string: str) -> bool:
+    def context_keys_exists(self, result: PotentialSecret, string: str) -> bool:
         if result.secret_value:
-            for secret_regex in self.skip_keys:
+            for secret_regex in self.context_keys:
                 regex = re.compile(
                     secret_regex.format(
                         secret=re.escape(result.secret_value),
-                    ), re.DOTALL,
+                    ), re.MULTILINE,
                 )
                 if regex.search(string) is not None:
                     return True

--- a/detect_secrets/plugins/azure_storage_key.py
+++ b/detect_secrets/plugins/azure_storage_key.py
@@ -31,7 +31,7 @@ class AzureStorageKeyDetector(RegexBasedDetector):
         r'(?i)azure.*\n?.*\n?.*{secret}',
 
         # maximum 2 lines secret distance above azure mention (case-insensitive)
-        r'{secret}.*\n?.*\n?.*(?i)azure',
+        r'(?i){secret}.*\n?.*\n?.*azure',
     ]
     def analyze_line(
             self,

--- a/detect_secrets/plugins/azure_storage_key.py
+++ b/detect_secrets/plugins/azure_storage_key.py
@@ -31,7 +31,7 @@ class AzureStorageKeyDetector(RegexBasedDetector):
         r'(?i)azure.*\n?.*\n?.*{secret}',
 
         # maximum 2 lines secret distance above azure mention (case-insensitive)
-        r'{secret}.*\n?.*\n?.*azure',
+        r'{secret}.*\n?.*\n?.*(?i)azure',
     ]
     def analyze_line(
             self,

--- a/tests/plugins/azure_storage_key_test.py
+++ b/tests/plugins/azure_storage_key_test.py
@@ -22,7 +22,7 @@ class TestAzureStorageKeyDetector:
             ),
             (
                 'lJzRc1YdHaAA2KCNJJ1tkYwF/+mKK6Ygw0NGe170Xu592euJv2wYUtBlV8z+qnlcNQSnIYVTkLWntUO1F8j8rQ==',  # noqa: E501
-                True,
+                False,
             ),
             (
                 'learS3Bucket',
@@ -48,7 +48,7 @@ class TestAzureStorageKeyDetector:
             ),
             (
                 'SshPublicKey: ssh-rsa lJzRc1YdHaAA2KCNJJ1tkYwF/+mKK6Ygw0NGe170Xu592euJv2wYUtBlV8z+qnlcNQSnIYVTkLWntUO1F8j8rQ==',
-                    False,
+                False,
             ),
             (
                 'PublicKeys: lJzRc1YdHaAA2KCNJJ1tkYwF/+mKK6Ygw0NGe170Xu592euJv2wYUtBlV8z+qnlcNQSnIYVTkLWntUO1F8j8rQ==',
@@ -59,15 +59,83 @@ class TestAzureStorageKeyDetector:
                 False,
             ),
             (
-                'PrivateKeys: lJzRc1YdHaAA2KCNJJ1tkYwF/+mKK6Ygw0NGe170Xu592euJv2wYUtBlV8z+qnlcNQSnIYVTkLWntUO1F8j8rQ==',
+                '(https://portal.azure.com/). +CREATE DATABASE SCOPED CREDENTIAL AzureStorageCredential +WITH IDENTITY = \'IDENTITY\', lJzRc1YdHaAA2KCNJJ1tkYwF/+mKK6Ygw0NGe170Xu592euJv2wYUtBlV8z+qnlcNQSnIYVTkLWntUO1F8j8rQ==',
                 True,
             ),
 
             # Test multilines
+
+            # azure is mentioned within the 1 line above
             (
-                """PrivateKeys:
-                - lJzRc1YdHaAA2KCNJJ1tkYwF/+mKK6Ygw0NGe170Xu592euJv2wYUtBlV8z+qnlcNQSnIYVTkLWntUO1F8j8rQ==""",
+                """(https://portal.azure.com/). +CREATE DATABASE SCOPED CREDENTIAL AzureStorageCredential +WITH IDENTITY = 'IDENTITY',
+                lJzRc1YdHaAA2KCNJJ1tkYwF/+mKK6Ygw0NGe170Xu592euJv2wYUtBlV8z+qnlcNQSnIYVTkLWntUO1F8j8rQ==""",
                 True,
+            ),
+            # azure is mentioned within the 2 lines above
+            (
+                """(https://portal.azure.com/). +CREATE DATABASE SCOPED CREDENTIAL AzureStorageCredential +WITH IDENTITY = 'IDENTITY',
+                some data here
+                lJzRc1YdHaAA2KCNJJ1tkYwF/+mKK6Ygw0NGe170Xu592euJv2wYUtBlV8z+qnlcNQSnIYVTkLWntUO1F8j8rQ==""",
+                True,
+            ),
+            # azure is mentioned within the 2 lines above
+            (
+                """(https://portal.azure.com/). +CREATE DATABASE SCOPED CREDENTIAL AzureStorageCredential +WITH IDENTITY = 'IDENTITY',
+
+                lJzRc1YdHaAA2KCNJJ1tkYwF/+mKK6Ygw0NGe170Xu592euJv2wYUtBlV8z+qnlcNQSnIYVTkLWntUO1F8j8rQ==""",
+                True,
+            ),
+            # azure is mentioned within the 3 lines above
+            (
+                """(https://portal.azure.com/). +CREATE DATABASE SCOPED CREDENTIAL AzureStorageCredential +WITH IDENTITY = 'IDENTITY',
+                some data 1
+                some data 2
+                lJzRc1YdHaAA2KCNJJ1tkYwF/+mKK6Ygw0NGe170Xu592euJv2wYUtBlV8z+qnlcNQSnIYVTkLWntUO1F8j8rQ==""",
+                False,
+            ),
+            # azure lowercase
+            (
+                """azure.com +WITH IDENTITY = 'IDENTITY',
+                lJzRc1YdHaAA2KCNJJ1tkYwF/+mKK6Ygw0NGe170Xu592euJv2wYUtBlV8z+qnlcNQSnIYVTkLWntUO1F8j8rQ==""",
+                True,
+            ),
+            # azure uppercase
+            (
+                """AZURE.com +WITH IDENTITY = 'IDENTITY',
+                lJzRc1YdHaAA2KCNJJ1tkYwF/+mKK6Ygw0NGe170Xu592euJv2wYUtBlV8z+qnlcNQSnIYVTkLWntUO1F8j8rQ==""",
+                True,
+            ),
+            # azure capitalize
+            (
+                """Azure.com +WITH IDENTITY = 'IDENTITY',
+                lJzRc1YdHaAA2KCNJJ1tkYwF/+mKK6Ygw0NGe170Xu592euJv2wYUtBlV8z+qnlcNQSnIYVTkLWntUO1F8j8rQ==""",
+                True,
+            ),
+            # azure is mentioned within the 1 line below
+            (
+                """lJzRc1YdHaAA2KCNJJ1tkYwF/+mKK6Ygw0NGe170Xu592euJv2wYUtBlV8z+qnlcNQSnIYVTkLWntUO1F8j8rQ==
+                (https://portal.azure.com/). +CREATE DATABASE SCOPED CREDENTIAL AzureStorageCredential +WITH IDENTITY = 'IDENTITY'
+                """,
+                True,
+            ),
+            # azure is mentioned within the 2 lines below
+            (
+                """
+                lJzRc1YdHaAA2KCNJJ1tkYwF/+mKK6Ygw0NGe170Xu592euJv2wYUtBlV8z+qnlcNQSnIYVTkLWntUO1F8j8rQ==
+                some data 1
+                (https://portal.azure.com/). +CREATE DATABASE SCOPED CREDENTIAL AzureStorageCredential +WITH IDENTITY = 'IDENTITY'
+                """,
+                True,
+            ),
+            # azure is mentioned within the 3 lines below
+            (
+                """
+                lJzRc1YdHaAA2KCNJJ1tkYwF/+mKK6Ygw0NGe170Xu592euJv2wYUtBlV8z+qnlcNQSnIYVTkLWntUO1F8j8rQ==
+                some data 1
+                some data 2
+                (https://portal.azure.com/). +CREATE DATABASE SCOPED CREDENTIAL AzureStorageCredential +WITH IDENTITY = 'IDENTITY'
+                """,
+                False,
             ),
             (
                 """SshPublicKeys:

--- a/tests/plugins/azure_storage_key_test.py
+++ b/tests/plugins/azure_storage_key_test.py
@@ -137,6 +137,29 @@ class TestAzureStorageKeyDetector:
                 """,
                 False,
             ),
+            # azure lowercase
+            (
+                    """
+                    lJzRc1YdHaAA2KCNJJ1tkYwF/+mKK6Ygw0NGe170Xu592euJv2wYUtBlV8z+qnlcNQSnIYVTkLWntUO1F8j8rQ==
+                    azure.com +WITH IDENTITY = 'IDENTITY',
+                    """,
+                    True,
+            ),
+            # azure uppercase
+            (
+                    """
+                    lJzRc1YdHaAA2KCNJJ1tkYwF/+mKK6Ygw0NGe170Xu592euJv2wYUtBlV8z+qnlcNQSnIYVTkLWntUO1F8j8rQ==
+                    AZURE.com +WITH IDENTITY = 'IDENTITY'""",
+                    True,
+            ),
+            # azure capitalize
+            (
+                    """
+                    lJzRc1YdHaAA2KCNJJ1tkYwF/+mKK6Ygw0NGe170Xu592euJv2wYUtBlV8z+qnlcNQSnIYVTkLWntUO1F8j8rQ==
+                    Azure.com +WITH IDENTITY = 'IDENTITY'
+                    """,
+                    True,
+            ),
             (
                 """SshPublicKeys:
                 - lJzRc1YdHaAA2KCNJJ1tkYwF/+mKK6Ygw0NGe170Xu592euJv2wYUtBlV8z+qnlcNQSnIYVTkLWntUO1F8j8rQ==""",

--- a/tests/plugins/azure_storage_key_test.py
+++ b/tests/plugins/azure_storage_key_test.py
@@ -111,6 +111,14 @@ class TestAzureStorageKeyDetector:
                 lJzRc1YdHaAA2KCNJJ1tkYwF/+mKK6Ygw0NGe170Xu592euJv2wYUtBlV8z+qnlcNQSnIYVTkLWntUO1F8j8rQ==""",
                 True,
             ),
+            # no azure mention
+            (
+                """
+                nomention.com +WITH IDENTITY = 'IDENTITY'
+                lJzRc1YdHaAA2KCNJJ1tkYwF/+mKK6Ygw0NGe170Xu592euJv2wYUtBlV8z+qnlcNQSnIYVTkLWntUO1F8j8rQ==
+                """,
+                False,
+            ),
             # azure is mentioned within the 1 line below
             (
                 """lJzRc1YdHaAA2KCNJJ1tkYwF/+mKK6Ygw0NGe170Xu592euJv2wYUtBlV8z+qnlcNQSnIYVTkLWntUO1F8j8rQ==
@@ -139,26 +147,34 @@ class TestAzureStorageKeyDetector:
             ),
             # azure lowercase
             (
-                    """
-                    lJzRc1YdHaAA2KCNJJ1tkYwF/+mKK6Ygw0NGe170Xu592euJv2wYUtBlV8z+qnlcNQSnIYVTkLWntUO1F8j8rQ==
-                    azure.com +WITH IDENTITY = 'IDENTITY',
-                    """,
-                    True,
+                """
+                lJzRc1YdHaAA2KCNJJ1tkYwF/+mKK6Ygw0NGe170Xu592euJv2wYUtBlV8z+qnlcNQSnIYVTkLWntUO1F8j8rQ==
+                azure.com +WITH IDENTITY = 'IDENTITY',
+                """,
+                True,
             ),
             # azure uppercase
             (
-                    """
-                    lJzRc1YdHaAA2KCNJJ1tkYwF/+mKK6Ygw0NGe170Xu592euJv2wYUtBlV8z+qnlcNQSnIYVTkLWntUO1F8j8rQ==
-                    AZURE.com +WITH IDENTITY = 'IDENTITY'""",
-                    True,
+                """
+                lJzRc1YdHaAA2KCNJJ1tkYwF/+mKK6Ygw0NGe170Xu592euJv2wYUtBlV8z+qnlcNQSnIYVTkLWntUO1F8j8rQ==
+                AZURE.com +WITH IDENTITY = 'IDENTITY'""",
+                True,
             ),
             # azure capitalize
             (
-                    """
-                    lJzRc1YdHaAA2KCNJJ1tkYwF/+mKK6Ygw0NGe170Xu592euJv2wYUtBlV8z+qnlcNQSnIYVTkLWntUO1F8j8rQ==
-                    Azure.com +WITH IDENTITY = 'IDENTITY'
-                    """,
-                    True,
+                """
+                lJzRc1YdHaAA2KCNJJ1tkYwF/+mKK6Ygw0NGe170Xu592euJv2wYUtBlV8z+qnlcNQSnIYVTkLWntUO1F8j8rQ==
+                Azure.com +WITH IDENTITY = 'IDENTITY'
+                """,
+                True,
+            ),
+            # no azure mention
+            (
+                """
+                lJzRc1YdHaAA2KCNJJ1tkYwF/+mKK6Ygw0NGe170Xu592euJv2wYUtBlV8z+qnlcNQSnIYVTkLWntUO1F8j8rQ==
+                nomention.com +WITH IDENTITY = 'IDENTITY'
+                """,
+                False,
             ),
             (
                 """SshPublicKeys:


### PR DESCRIPTION
`AccountKey=` is before the key

azure (case insensitive) is mentioned within the context of the secret (within the surrounding 2 lines)

* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added


* **What kind of change does this PR introduce?**
AzureStorageKeyDetector should flag a secret in two scenarios:

1. `AccountKey=` is before the key 
2. `azure`  (case insensitive) is mentioned within the context of the secret (within the surrounding 2 lines)
