### PR TITLE
Do not require leading quotes for high-entropy strings in ini and yaml

### DIFF
--- a/detect_secrets/plugins/high_entropy_strings.py
+++ b/detect_secrets/plugins/high_entropy_strings.py
@@ -30,7 +30,7 @@ class HighEntropyStringsPlugin(BasePlugin, metaclass=ABCMeta):
 
         # We require quoted strings to reduce noise.
         # NOTE: We need this to be a capturing group, so back-reference can work.
-        self.regex = re.compile(r'([\'":=])\s*([{}]+)([\'"]?)'.format(re.escape(charset)))
+        self.regex = re.compile(r'([\'":=])\s*([{}]+)([\'"]|$)'.format(re.escape(charset)))
 
     def analyze_string(self, string: str) -> Generator[str, None, None]:
         for result in self.regex.findall(string):


### PR DESCRIPTION
Do not require leading quotes for high-entropy strings in ini and yaml