### PR TITLE
Use standardised build metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,12 +81,8 @@ jobs:
           echo "version=$new_tag" >> "$GITHUB_OUTPUT"
       - name: create python package
         run: |
-          python -m pip install wheel
-          python setup.py sdist bdist_wheel
-      - name: rename dist files
-        run: |
-          shopt -s nullglob
-          for file in dist/bc-*.gz; do mv "$file" "${file//bc-detect-secrets/bc_detect_secrets}" ; done
+          python -m pip install build
+          python -m build
       - name: Publish a Python distribution to PyPI
         uses: pypa/gh-action-pypi-publish@b7f401de30cb6434a1e19f805ff006643653240e  # v1
       - name: sleep and wait for package to refresh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools>=70"]
+build-backend = "setuptools.build_meta"
+
 [tool.ruff]
 line-length = 100
 


### PR DESCRIPTION
Hi,

This PR changes the `bc-detect-secrets` package to build using standardised metadata. Recent versions of Python no longer automatically inject `setuptools` and `wheel`. The supported way to declare build dependencies, such as setuptools, is via the `[build-system]` table in `pyproject.toml` 

With this, you no longer need the file renaming workaround.

Please let me know if you have any questions!

A