### PR TITLE
fix(azure_storage_key): broaden azure storage account key pattern

### DIFF
--- a/detect_secrets/plugins/azure_storage_key.py
+++ b/detect_secrets/plugins/azure_storage_key.py
@@ -18,7 +18,8 @@ class AzureStorageKeyDetector(RegexBasedDetector):
     """Scans for Azure Storage Account access keys."""
     secret_type = 'Azure Storage Account access key'
 
-    account_key = 'AccountKey'
+    account_key = r'account[_]?k(?:ey)?\b'
+    account_key_check = re.compile(r'account[_]?k(?:ey)?\b', re.IGNORECASE)
     azure = 'azure'
 
     max_line_length = 4000
@@ -28,12 +29,12 @@ class AzureStorageKeyDetector(RegexBasedDetector):
     denylist = [
         # Account Key (AccountKey=xxxxxxxxx)
         re.compile(
-            r'(?:["\']?[A-Za-z0-9+\/]{86,1000}==["\']?)',
+            r'(?:["\']?[A-Za-z0-9+\/]{86,88}==["\']?)',
         ),
     ]
 
     context_keys = [
-        r'{account_key}=\s*{secret}',
+        r'(?i){account_key}[\s=]{{1,20}}{secret}',
 
         # maximum 2 lines secret distance under azure mention (case-insensitive)
         r'(?i)\b{azure}(.*\n){{0,2}}.*{secret}',
@@ -89,7 +90,7 @@ class AzureStorageKeyDetector(RegexBasedDetector):
                         azure=self.azure,
                     ), re.MULTILINE,
                 )
-                if regex.pattern.startswith(self.account_key) and self.account_key not in string:
+                if self.account_key in regex.pattern and not self.account_key_check.search(string):
                     continue
                 if self.azure in regex.pattern.lower() and self.azure not in string.lower():
                     continue

--- a/tests/plugins/azure_storage_key_test.py
+++ b/tests/plugins/azure_storage_key_test.py
@@ -215,6 +215,11 @@ class TestAzureStorageKeyDetector:
                     """,
                     False,
             ),
+            # Flexible account key variable names
+            (
+                'STORAGE_ACCOUNT_K=X1y2Z3w4V5u6T7s8R9q0P1o2N3m4L5k6J7h8G9f0E1d2C3b4A5B6C7D8E9F0G1H2I3J4K5L6M7N8O9P0Q1R2S3==',  # noqa: E501
+                True,
+            ),
             (
                     'CosmosKey=lJzRc1YdHaAA2KCNJJ1tkYwF/+mKK6Ygw0NGe170Xu592euJv2wYUtBlV8z+qnlcNQSnIYVTkLWntUO1F8j8rQ==',
                     False,


### PR DESCRIPTION

- Changed account_key context pattern from literal 'AccountKey' to regex 'account[_]?k(?:ey)?\b' (case-insensitive) to match variable names like STORAGE_ACCOUNT_K, STORAGE_ACCOUNT_KEY, account_key, AccountKey, etc.
- Narrowed denylist base64 range from {86,1000} to {86,88} to match actual Azure Storage key length (64 bytes = 86 base64 chars + '==')
- Updated early-exit optimization to use regex-based check instead of literal string match
- Added unit test for STORAGE_ACCOUNT_K=<secret> pattern

* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added
<!-- (for bug fixes / features) -->
- [ ] Docs have been added / updated
<!-- (for bug fixes / features) -->
- [ ] All CI checks are green

* **What kind of change does this PR introduce?**
<!-- (Bug fix, feature, docs update, ...) -->

* **What is the current behavior?**
<!-- (You can also link to an open issue here) -->

* **What is the new behavior (if this is a feature change)?**

* **Does this PR introduce a breaking change?**
<!-- (What changes might users need to make in their application due to this PR?) -->

* **Other information**:
